### PR TITLE
Add RAG backend with file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An AI-powered, self-hosted Ask-Me-Anything system for Inovus Labs. Ask questions
 This project implements a custom **Retrieval Augmented Generation (RAG)** pipeline using:
 
 ✅  **Gemini API** for both embeddings and answer generation  
-✅  **Cloudflare Vectorize DB** for efficient, scalable vector search  
+✅  **Pinecone** for efficient, scalable vector search
 ✅  **Cloudflare R2** for secure document storage  
 ✅  A modern **Nuxt 3** frontend for seamless user interaction  
 ✅  Node.js + Hono API backend for orchestrating the RAG flow  
@@ -34,7 +34,7 @@ Check out the live demo at [Inovus Labs AMA](https://ama.inovuslabs.com) (curren
 |-----------------|-------------------------------------|
 | Frontend        | Nuxt 3 (Vue 3) + Tailwind CSS      |
 | RAG Backend     | Node.js + Hono                     |
-| Vector Storage  | VectorizeDB                        |
+| Vector Storage  | Pinecone                           |
 | Document Storage| Cloudflare R2                      |
 | Embeddings      | Gemini API (embedding-001)         |
 | Completion      | Gemini API (models/gemini-pro)     |
@@ -49,18 +49,20 @@ Check out the live demo at [Inovus Labs AMA](https://ama.inovuslabs.com) (curren
 ✅ Gemini-powered completion with custom prompts  
 ✅ Scalable, production-grade RAG setup  
 ✅ Rate limiting & abuse prevention  
-✅ Clean, mobile-friendly chat interface  
-✅ Future-ready for live knowledge via MCP Server  
+✅ Clean, mobile-friendly chat interface
+✅ Future-ready for live knowledge via MCP Server
+✅ Upload files of any format via a dedicated API route
+✅ Sources for each answer are returned for UI display
 
 
 ## 🛠️ How It Works
 
 1. User asks a question via the Nuxt frontend
 2. API server generates a question embedding (Gemini)
-3. VectorizeDB returns relevant knowledge chunks
+3. Pinecone returns relevant knowledge chunks
 4. System composes a grounded prompt
 5. Gemini API generates a final answer
-6. Response is displayed in the chat UI
+6. Response with source references is displayed in the chat UI
 
 In the future, the system will also pull real-time knowledge from the **Inovus MCP Server**.
 
@@ -75,4 +77,4 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 * [ ] Streaming answers to frontend
 * [ ] Advanced rate limiting with Cloudflare Workers
 * [ ] **MCP Server integration for real-time knowledge**
-* [ ] Source citations and traceability
+* [x] Source citations and traceability

--- a/server/src/lib/r2.ts
+++ b/server/src/lib/r2.ts
@@ -1,0 +1,8 @@
+import { env } from 'hono/adapter'
+
+// Uploads a File to Cloudflare R2 and returns the object key
+export async function uploadToR2(file: File): Promise<string> {
+  const key = `${Date.now()}_${file.name}`
+  await env.DOCS_BUCKET.put(key, file.stream())
+  return key
+}

--- a/server/wrangler.jsonc
+++ b/server/wrangler.jsonc
@@ -2,37 +2,19 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "inobot-server",
   "main": "src/index.ts",
-  "compatibility_date": "2025-06-23"
-  // "compatibility_flags": [
-  //   "nodejs_compat"
-  // ],
-  // "vars": {
-  //   "MY_VAR": "my-variable"
-  // },
-  // "kv_namespaces": [
-  //   {
-  //     "binding": "MY_KV_NAMESPACE",
-  //     "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-  //   }
-  // ],
-  // "r2_buckets": [
-  //   {
-  //     "binding": "MY_BUCKET",
-  //     "bucket_name": "my-bucket"
-  //   }
-  // ],
-  // "d1_databases": [
-  //   {
-  //     "binding": "MY_DB",
-  //     "database_name": "my-database",
-  //     "database_id": ""
-  //   }
-  // ],
-  // "ai": {
-  //   "binding": "AI"
-  // },
-  // "observability": {
-  //   "enabled": true,
-  //   "head_sampling_rate": 1
-  // }
+  "compatibility_date": "2025-06-23",
+  "r2_buckets": [
+    {
+      "binding": "DOCS_BUCKET",
+      "bucket_name": "inovus-docs"
+    }
+  ],
+  "vars": {
+    "PINECONE_API_KEY": "",
+    "PINECONE_INDEX": "",
+    "PINECONE_PROJECT_ID": "",
+    "PINECONE_ENVIRONMENT": "",
+    "GEMINI_API_KEY": "",
+    "MCP_SERVER_URL": ""
+  }
 }


### PR DESCRIPTION
## Summary
- integrate Pinecone and Cloudflare R2
- allow file uploads and index them
- return references with answers
- document new features and config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a5ea0d3f88321a497ad36cfdadf94